### PR TITLE
Typo and link correction

### DIFF
--- a/get-involved/content-ideas.md
+++ b/get-involved/content-ideas.md
@@ -23,7 +23,7 @@ If you're interested in contributing to one of these topics or have your own ide
 
 How to Contribute:
 
-1. Join the EthStaker Discord server: [https://discord.io/ethstaker](https://discord.io/ethstaker)
+1. Join the EthStaker Discord server: [discord.com/invite/ethstaker](discord.com/invite/ethstaker)
 2. Head over to the [#knowledge-base channel](https://discord.com/channels/694822223575384095/1085669876795985920).
 3. Express your interest in contributing to a specific topic or idea or pitch your own idea.
 4. Collaborate with our team and community members to gather resources, guidance, and support.

--- a/networking/brute-force-ssh-protection.md
+++ b/networking/brute-force-ssh-protection.md
@@ -23,7 +23,7 @@ maxretry = 5
 {% endcode %}
 
 {% hint style="info" %}
-If you're using a non-standard SSH port that isn't `22` then you will need to change that in the cofig file above.
+If you're using a non-standard SSH port that isn't `22` then you will need to change that in the config file above.
 {% endhint %}
 
 You can change the `maxretry` setting, which is the number of attempts it will allow before locking the offending address out.


### PR DESCRIPTION
### Typo and link correction

**ethstaker-knowledgebase/blob/main/networking/brute-force-ssh-protection.md**

Typo:

"cofig" should be "config. Corrected.

**ethstaker-knowledgebase/blob/main/get-involved/content-ideas.md**

Issue with a link:

"discord.io/ethstaker" should be "discord.com/invite/ethstaker" to ensure the link works properly (as "discord.io" is not the official domain for Discord invites). Corrected.