### PR TITLE
Typo Update slashing-explained.md

### DIFF
--- a/help/slashing-explained.md
+++ b/help/slashing-explained.md
@@ -15,7 +15,7 @@ Slashing is a term used to describe the response of the Ethereum network to a va
 If someone wanted to attack the Ethereum network they could propose multiple blocks or attest to multiple conflicting blocks. To disincentivize attacks on the network, in a [Proof of Stake (PoS)](../staking-glossary.md#proof-of-stake-pos) system, validators have something at stake, which is currently 32 ETH per validator. When a validator breaks the rules of the network, two things will happen:
 
 1. The validator has some amount of ETH taken from that initial 32 ETH staked balance.
-2. The validator is force exited and removed from the [validator pool](../staking-glossary.md#validator-pool).
+2. The validator is forced exit and removed from the [validator pool](../staking-glossary.md#validator-pool).
 
 The amount of ETH taken as a penalty varies on the state of the network. If a small number of validators are slashed simultaneously, then a rough estimate of the slashing penalty is 1 or 2 ETH. In an incredibly rare Black Swan event, when a large portion of the network is simultaneously offline or breaking the rules (e.g. in a coordinated attack) then the slashing penalty can be up to and including 100% of the stake.
 


### PR DESCRIPTION
### Description

There is a minor grammatical issue in the documentation where the phrase **"force exited"** is used. The correct terminology should be **"forced exit"**, as it better aligns with standard phrasing and makes the meaning clearer.

### Changes

- Replaced **"force exited"** with **"forced exit"** in the sentence:

  ```
  The validator is forced exit and removed from the [validator pool](../staking-glossary.md#validator-pool).
  ```

### Why This Is Important

Correct terminology ensures the documentation is clear and consistent. Using **"forced exit"** is the proper phrasing in the context of Ethereum staking, helping users understand the process better and avoid any confusion. Making this change improves the accuracy of the documentation and enhances readability.