### PR TITLE
Typo Update withdrawal-process-explained.md

### DIFF
--- a/getting-started/withdrawal-process-explained.md
+++ b/getting-started/withdrawal-process-explained.md
@@ -12,7 +12,7 @@ Providing a withdrawal address is required before _any_ funds can be transferred
 
 Users looking to exit staking entirely and withdraw their full balance back must also sign and broadcast a "voluntary exit" message with validator keys which will start the process of exiting from staking. This is done with your validator client and submitted to your beacon node, and does not require gas.
 
-The process of a validator exiting from staking takes variable amounts of time, depending on how many others are exiting at the same time. Once complete, this account will no longer be responsible for performing validator network duties, is no longer eligible for rewards, and no longer has their ETH "at stake". At this time the account with be marked as fully “withdrawable”.
+The process of a validator exiting from staking takes variable amounts of time, depending on how many others are exiting at the same time. Once complete, this account will no longer be responsible for performing validator network duties, is no longer eligible for rewards, and no longer has their ETH "at stake". At this time the account will be marked as fully “withdrawable”.
 
 Once an account is flagged as "withdrawable", and withdrawal credentials have been provided, there is nothing more a user needs to do aside from wait. Accounts are automatically and continuously swept by block proposers for eligible exited funds, and your account balance will be transferred in full (also known as a "full withdrawal") during the next [sweep](https://ethereum.org/en/staking/withdrawals/#validator-sweeping).
 


### PR DESCRIPTION
**Description**:

This PR addresses a minor typo in the documentation. The phrase **"with be"** has been corrected to **"will be"** in the sentence:

- Original: "At this time the account **with be** marked as fully “withdrawable”."
- Corrected: "At this time the account **will be** marked as fully “withdrawable”."

**Importance**:

The phrase "with be" was a grammatical error, which can affect the readability and clarity of the documentation. Correcting this typo ensures the sentence is clear and maintains professional language standards. While it doesn’t affect functionality, such small errors can detract from the quality of the documentation and may lead to confusion for readers.

Please review and approve the change.
