### PR TITLE
Typo Update downtime-explained.md

### DIFF
--- a/help/downtime-explained.md
+++ b/help/downtime-explained.md
@@ -32,7 +32,7 @@ If you miss your block proposal, the [slot](https://github.com/Buttaa/ethstaker/
 
 ### Can I be slashed for being offline?
 
-No. Realistically, the only condition that can cause a [slashing event](https://github.com/Buttaa/ethstaker/blob/main/help/staking-glossary.md#slashable-offenses) is if you run your validator's keys on two nodes at the same time (such as a failover / redundancy setup, where your backup node accidentally turns on while your main node is still running). Don't let this happen, and you won't get slashed. **Slashing cannot occur from being offline for maintenance**.
+No. Realistically, the only condition that can cause a [slashing event](https://github.com/Buttaa/ethstaker/blob/main/help/staking-glossary.md#slashable-offenses) is if you run your validator's keys on two nodes at the same time (such as a failover / redundancy setup, where your backup node accidentally turns on while your main node is still running). Don't let this happen, and you won't get slashed. **A slashing event cannot occur from being offline for maintenance**.
 
 ## What if I can't recover my validator and/or I want to stop staking?
 


### PR DESCRIPTION
I found a small inconsistency in the text where the phrase **"slashing cannot occur from being offline for maintenance"** was used. The word "slashing" is more commonly referred to as **"a slashing event"** for clarity and consistency with Ethereum documentation.

#### Fix:
I have updated the sentence to improve the clarity:

From:
> "slashing cannot occur from being offline for maintenance"

To:
> "A slashing event cannot occur from being offline for maintenance."

#### Importance:
This change improves the clarity of the statement, ensuring that readers understand that the term "slashing" refers specifically to a slashing event, which is a more precise way of describing what happens in case of validator misbehavior. It also ensures consistency with Ethereum's technical terminology, making the content easier to understand for both beginners and advanced users.

#### Conclusion:
This is a minor adjustment that enhances the accuracy of the explanation without altering the meaning of the content. Other than this, the text appears to be error-free.