### PR TITLE
Typo Update obol-dvt.md

### DIFF
--- a/dvt/obol-dvt.md
+++ b/dvt/obol-dvt.md
@@ -62,7 +62,7 @@ Copy the sample `.env` file.
 cp .env.sample .env
 ```
 
-Uncomment (remove the `#`) the line `CHARON_BEACON_NODE_ENDPOINTS`. Add your existing Beacon Node IP address, for example `"http://192.168.1.8:5052"`. As the Charon Client is running inside a Docker container you can't use `localhost`, even though might be running on the same physical machine, it requires the IP address of the host machine.
+Uncomment (remove the `#`) the line `CHARON_BEACON_NODE_ENDPOINTS`. Add your existing Beacon Node IP address, for example `"http://192.168.1.8:5052"`. As the Charon Client is running inside a Docker container you can't use `localhost`, even though it might be running on the same physical machine, it requires the IP address of the host machine.
 
 {% code title=".env" %}
 ```


### PR DESCRIPTION
### Typographical Error Found

#### Issue
In the following sentence under **"Uncomment (remove the `#`) the line `CHARON_BEACON_NODE_ENDPOINTS`"**:

> "...even though might be running on the same physical machine, it requires the IP address of the host machine."

The phrase **"even though might be running"** is missing a subject. It should read:

> "...even though it might be running on the same physical machine, it requires the IP address of the host machine."

#### Suggested Correction
Insert **"it"** after "though" to correct the sentence:

> "...even though it might be running on the same physical machine, it requires the IP address of the host machine."

#### Importance of Fix
- **Clarity:** Fixing the sentence ensures proper grammar, making the instructions more understandable.
- **Professionalism:** Well-structured and grammatically correct documentation maintains the credibility of the content.
