### PR TITLE
docs: Fixed incorrect wording Update firewalls-and-subnetting.md

### DIFF
--- a/networking/firewalls-and-subnetting.md
+++ b/networking/firewalls-and-subnetting.md
@@ -1,6 +1,6 @@
 # Firewalls and subnetting
 
-A firewall is a security mechanism that monitors both incoming and outgoing network connections and can either accept or reject traffic based on a set of configurable rules. It is heavily recommended to have one configured to improve the security of your node/validator setup.
+A firewall is a security mechanism that monitors both incoming and outgoing network connections and can either accept or reject traffic based on a set of configurable rules. It is strongly recommended to have one configured to improve the security of your node/validator setup.
 
 There are two kinds of firewalls:
 


### PR DESCRIPTION
In the "Firewalls and subnetting" section, I corrected the phrase:

> "It is heavily recommended to have one configured to improve the security of your node/validator setup."

The word "heavily" was incorrectly used here. The correct version is:

> "It is strongly recommended to have one configured to improve the security of your node/validator setup."

This small change improves the clarity and correctness of the sentence.