### PR TITLE
docs: update dead link `obol-dvt.md`

### DIFF
--- a/dvt/obol-dvt.md
+++ b/dvt/obol-dvt.md
@@ -18,7 +18,7 @@ On your existing Beacon Node, ensure these flags are added so the Charon client 
 --http-port=5052
 ```
 
-[https://lighthouse-book.sigmaprime.io/api-bn.html#starting-the-server](https://lighthouse-book.sigmaprime.io/api-bn.html#starting-the-server)
+[https://lighthouse-book.sigmaprime.io/api_bn.html#starting-the-server](https://lighthouse-book.sigmaprime.io/api_bn.html#starting-the-server)
 {% endtab %}
 
 {% tab title="Teku Flags" %}


### PR DESCRIPTION
Hi! I updated a broken link to Lighthouse Beacon Node API documentation in the `Obol DVT`.