### PR TITLE
Removed External MEV Relay dead links

### DIFF
--- a/docs/en/guides/MEV-relay-list.md
+++ b/docs/en/guides/MEV-relay-list.md
@@ -32,20 +32,12 @@ Selecting your relays **can be an important decision** for some stakers. You sho
 
 ## External relay monitoring
 
-* [MEV Panda](https://www.mevpanda.com) by OreoMev
-* [calldata.pics](https://calldata.pics) by Toni Wahrstätter
 * [censorship.pics](https://censorship.pics) by Toni Wahrstätter
 * [mevboost.pics](https://www.mevboost.pics/) by Toni Wahrstätter
-* [timing.pics](https://timing.pics) by Toni Wahrstätter
 * [tornado.pics](https://tornado.pics) by Toni Wahrstätter
 * [MEV Watch](https://www.mevwatch.info/) by Labrys
 * [Relays](https://beaconcha.in/relays) from beaconcha.in
 * [Relay Scan](https://www.relayscan.io) from Chris Hager
-* [Transparency dashboard](https://transparency.flashbots.net/) by Flashbots
-* [Relay Monitor](https://app.metrika.co/ethereum/dashboard/mev/relay-overview?tr=1d) by Metrika
-* [Rated Network](https://www.rated.network/relays?network=mainnet) by Rated Network
-* [Inclusion Watch](https://www.inclusion.watch) by donnoh.eth and emiliano.eth
-* [Neutrality Watch](https://eth.neutralitywatch.com/) specifically analyses Lido operators. [Github](https://github.com/mikgur/Ethereum-censorability-monitor).
 
 # MEV relay list for Hoodi testnet
 


### PR DESCRIPTION
Some links are dead, and some are hijacked by malicious actors. Last one is fake airdrop wallet drain.