### PR TITLE
Add OpenChainBench to RPC endpoint guide

### DIFF
--- a/docs/en/tutorials/rpc-endpoint.md
+++ b/docs/en/tutorials/rpc-endpoint.md
@@ -136,3 +136,7 @@ If your RPC is unavailable or otherwise inaccessible, it may show an error when 
 <figure><img src="/assets/img/gitbook/image (3) (1).png" alt=""><figcaption></figcaption></figure>
 
 Success! Now you can use Metamask as you normally would with the added benefit of accessing the Ethereum network through your own node 🥳
+
+## Benchmarking your RPC provider
+
+When relying on a third-party RPC endpoint as backup, use [OpenChainBench](https://openchainbench.com) to compare providers by latency and stale-state probability across multiple regions before committing. It is open-source and requires no API key.


### PR DESCRIPTION
Adds a brief mention of OpenChainBench in the RPC endpoint section. Solo stakers who rely on a third-party RPC as backup benefit from knowing which providers are fastest and least likely to return stale data. OCB provides this comparison continuously, for free, MIT licensed.